### PR TITLE
epoch default resolution

### DIFF
--- a/src/specification.rs
+++ b/src/specification.rs
@@ -415,34 +415,10 @@ impl Deme {
         Ok(())
     }
 
-    fn check_empty_epochs(&mut self, defaults: &Option<GraphDefaults>) -> Result<(), DemesError> {
-        if !self.0.borrow().epochs.is_empty() {
-            return Ok(());
+    fn check_empty_epochs(&mut self) {
+        if self.0.borrow().epochs.is_empty() {
+            self.0.borrow_mut().epochs.push(Epoch::default());
         }
-
-        match defaults.as_ref() {
-            Some(&graph_defaults) => match graph_defaults.epoch.as_ref() {
-                Some(&epoch_defaults) => {
-                    let e = Epoch {
-                        start_size: Some(epoch_defaults.start_size),
-                        ..Default::default()
-                    };
-                    self.0.borrow_mut().epochs.push(e);
-                }
-                None => {
-                    return Err(DemesError::TopLevelError(
-                        "missing default start_size for epoch".to_string(),
-                    ));
-                }
-            },
-            None => {
-                return Err(DemesError::TopLevelError(
-                    "missing top-level defaults".to_string(),
-                ));
-            }
-        }
-
-        Ok(())
     }
 
     // Make the internal data match the MDM spec
@@ -451,7 +427,7 @@ impl Deme {
         deme_map: &DemeMap,
         defaults: Option<GraphDefaults>,
     ) -> Result<(), DemesError> {
-        self.check_empty_epochs(&defaults)?;
+        self.check_empty_epochs();
         assert!(self.0.borrow().ancestor_map.is_empty());
         self.resolve_times(deme_map)?;
         self.resolve_sizes()?;

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -366,7 +366,7 @@ impl Deme {
 
             match defaults {
                 Some(d) => {
-                    d.apply_epoch_defaults(&mut temp_epoch);
+                    d.apply_epoch_defaults(temp_epoch);
                 }
                 None => (),
             }

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -363,7 +363,7 @@ impl Deme {
             if temp_epoch.start_size.is_none() && temp_epoch.end_size.is_none() {
                 return Err(DemesError::EpochError(format!(
                     "first epoch of deme {} must define one or both of start_size and end_size",
-                    self.name()
+                    self_borrow.name
                 )));
             }
             if temp_epoch.start_size.is_none() {
@@ -378,7 +378,7 @@ impl Deme {
         if self_borrow.start_time == StartTime::default() && epoch_sizes.0 != epoch_sizes.1 {
             let msg = format!(
                     "first epoch of deme {} cannot have varying size and an infinite time interval: start_size = {}, end_size = {}",
-                    self.name(), f64::from(epoch_sizes.0.unwrap()), f64::from(epoch_sizes.1.unwrap()),
+                    self_borrow.name, f64::from(epoch_sizes.0.unwrap()), f64::from(epoch_sizes.1.unwrap()),
                 );
             return Err(DemesError::EpochError(msg));
         }

--- a/tests/test_graph.rs
+++ b/tests/test_graph.rs
@@ -1,4 +1,39 @@
 #[test]
+fn test_tutorial_example_01() {
+    let yaml = "
+# Comments start with a hash.
+description:
+  Asymmetric migration between two extant demes.
+time_units: generations
+defaults:
+  epoch:
+    start_size: 5000
+demes:
+  - name: X
+    epochs:
+      - end_time: 1000
+  - name: A
+    ancestors: [X]
+  - name: B
+    ancestors: [X]
+    epochs:
+      - start_size: 2000
+        end_time: 500
+      - start_size: 400
+        end_size: 10000
+";
+
+    let _migrations = "
+migrations:
+  - source: A
+    dest: B
+    rate: 1e-4
+";
+    let g = demes::loads(yaml).unwrap();
+    let _ = serde_yaml::to_string(&g).unwrap();
+}
+
+#[test]
 fn tutorial_example_03() {
     let yaml = "
 time_units: generations


### PR DESCRIPTION
- add failing test
- fix multiple mutable borrow error
- when there are no epochs specified, add Epoch::default()
- fix propagation of epoch defaults. allow for default end_size
