### PR TITLE
Fix epoch sizes during Graph round trips

### DIFF
--- a/src/specification.rs
+++ b/src/specification.rs
@@ -600,8 +600,14 @@ impl Deme {
             match defaults {
                 Some(d) => d.apply_epoch_defaults(epoch),
                 None => {
-                    epoch.start_size = last_end_size;
-                    epoch.end_size = epoch.start_size;
+                    match epoch.start_size {
+                        Some(_) => (),
+                        None => epoch.start_size = last_end_size,
+                    }
+                    match epoch.end_size {
+                        Some(_) => (),
+                        None => epoch.end_size = epoch.start_size,
+                    }
                 }
             }
             last_end_size = epoch.end_size;

--- a/tests/test_graph.rs
+++ b/tests/test_graph.rs
@@ -76,7 +76,8 @@ migrations:
     rate: 1e-4
 ";
     let g = demes::loads(yaml).unwrap();
-    let _ = serde_yaml::to_string(&g).unwrap();
+    let s = serde_yaml::to_string(&g).unwrap();
+    let _ = demes::loads(&s).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Loading -> serializing -> loading a Graph seems to be broken where
epoch defaults are in play.
