### PR TITLE
Test examples from demes-spec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "demes-spec"]
+	path = demes-spec
+	url = https://github.com/popsim-consortium/demes-spec

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ regex = "~1"
 
 [dev-dependencies]
 serde_json = "1.0.81"
+glob = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,14 @@ mod macros;
 mod error;
 pub mod specification;
 
+use std::io::Read;
+
 pub use error::DemesError;
 
 pub fn loads(yaml: &str) -> Result<specification::Graph, DemesError> {
     specification::Graph::new_resolved_from_str(yaml)
+}
+
+pub fn load<T: Read>(reader: T) -> Result<specification::Graph, DemesError> {
+    specification::Graph::new_resolved_from_reader(reader)
 }

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -9,6 +9,7 @@ use std::cell::{Ref, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::fmt::Display;
+use std::io::Read;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -1690,8 +1691,20 @@ impl Graph {
         Ok(g)
     }
 
+    pub(crate) fn new_from_reader<T: Read>(reader: T) -> Result<Self, DemesError> {
+        let g: Self = serde_yaml::from_reader(reader)?;
+        Ok(g)
+    }
+
     pub(crate) fn new_resolved_from_str(yaml: &'_ str) -> Result<Self, DemesError> {
         let mut graph = Self::new_from_str(yaml)?;
+        graph.resolve()?;
+        graph.validate()?;
+        Ok(graph)
+    }
+
+    pub(crate) fn new_resolved_from_reader<T: Read>(reader: T) -> Result<Self, DemesError> {
+        let mut graph = Self::new_from_reader(reader)?;
         graph.resolve()?;
         graph.validate()?;
         Ok(graph)

--- a/tests/test_cases_from_spec.rs
+++ b/tests/test_cases_from_spec.rs
@@ -1,0 +1,49 @@
+use glob::glob;
+
+fn invalid_file_skip_list() -> std::collections::HashSet<String> {
+    let mut rv = std::collections::HashSet::default();
+
+    rv.insert("demes-spec/test-cases/invalid/bad_demelevel_defaults_epoch_43.yaml".to_string());
+    rv.insert("demes-spec/test-cases/invalid/bad_toplevel_defaults_epoch_43.yaml".to_string());
+    rv.insert("demes-spec/test-cases/invalid/bad_size_function_04.yaml".to_string());
+
+    rv
+}
+
+fn process_path(
+    path: &str,
+    skip_list: Option<std::collections::HashSet<String>>,
+) -> (Vec<String>, Vec<String>) {
+    let paths = glob(path).unwrap();
+    let mut failures = vec![];
+    let mut successes = vec![];
+    for path in paths {
+        let name = path.unwrap();
+        let should_skip = match skip_list.as_ref() {
+            None => false,
+            Some(sl) => sl.contains(&name.clone().to_str().unwrap().to_string()),
+        };
+
+        if !should_skip {
+            let file = std::fs::File::open(name.clone()).unwrap();
+            match demes::load(file) {
+                Ok(_) => successes.push(name.to_str().unwrap().to_owned()),
+                Err(_) => failures.push(name.to_str().unwrap().to_owned()),
+            }
+        }
+    }
+    (successes, failures)
+}
+
+#[test]
+fn load_valid_graphs() {
+    let rv = process_path("demes-spec/test-cases/valid/*.yaml", None);
+    assert!(rv.1.is_empty(), "{:?}", rv.1);
+}
+
+#[test]
+fn load_invalid_graphs() {
+    let skip_list = Some(invalid_file_skip_list());
+    let rv = process_path("demes-spec/test-cases/invalid/*.yaml", skip_list);
+    assert!(rv.0.is_empty(), "{:?}", rv.0);
+}


### PR DESCRIPTION
- minimal code to load/evaluate YAML files from spec repo
- some tweaking
- add demes-spec submodule
- add demes-spec submodule
- start to establish a testing pattern
- bulk-process all valid graphs
- refactor a bit
- process the bad ones, too
- fix assert
- print...
- fix
- add a skip list
- skip more serde_yaml panic conditions
- remove print
