### PR TITLE
Add minimal semantics to construct empty Builder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,33 @@
+use crate::specification::Graph;
+use crate::specification::TimeUnits;
+use crate::DemesError;
+
+pub struct GraphBuilder {
+    graph: Graph,
+}
+
+impl GraphBuilder {
+    pub fn new(time_units: TimeUnits) -> Self {
+        Self {
+            graph: Graph::new_from_time_units(time_units),
+        }
+    }
+
+    pub fn resolve(self) -> Result<Graph, DemesError> {
+        let mut builder = self;
+        builder.graph.resolve()?;
+        Ok(builder.graph)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn new_builder() {
+        let b = GraphBuilder::new(TimeUnits::GENERATIONS);
+        b.resolve().unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@
 
 mod macros;
 
+#[allow(dead_code)]
+mod builder;
 mod error;
 pub mod specification;
 

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -1698,6 +1698,25 @@ impl PartialEq for Graph {
 impl Eq for Graph {}
 
 impl Graph {
+    pub(crate) fn new_from_time_units(time_units: TimeUnits) -> Self {
+        Self {
+            time_units,
+
+            // remaining fields have defaults
+            description: Option::<String>::default(),
+            doi: Option::<Vec<String>>::default(),
+            input_defaults: GraphDefaultInput::default(),
+            defaults: GraphDefaults::default(),
+            metadata: Metadata::default(),
+            generation_time: Option::<GenerationTime>::default(),
+            demes: Vec::<Deme>::default(),
+            input_migrations: Vec::<UnresolvedMigration>::default(),
+            resolved_migrations: Vec::<AsymmetricMigration>::default(),
+            pulses: Vec::<Pulse>::default(),
+            deme_map: DemeMap::default(),
+        }
+    }
+
     pub(crate) fn new_from_str(yaml: &'_ str) -> Result<Self, DemesError> {
         let g: Self = serde_yaml::from_str(yaml)?;
         Ok(g)
@@ -2033,6 +2052,11 @@ impl Graph {
     }
 
     pub(crate) fn resolve(&mut self) -> Result<(), DemesError> {
+        if self.demes.is_empty() {
+            return Err(DemesError::DemeError(
+                "no demes have been specified".to_string(),
+            ));
+        }
         std::mem::swap(&mut self.defaults, &mut self.input_defaults.defaults);
         self.deme_map = self.build_deme_map()?;
 


### PR DESCRIPTION
- Add failing test.
- Add Graph::new_from_time_units
- make tests pass
- allow(dead_code)
