### PR TITLE
Streamling internal code for serializing deme-level defaults.

### DIFF
--- a/src/specification.rs
+++ b/src/specification.rs
@@ -896,9 +896,9 @@ pub struct DemeData {
     epochs: Vec<Epoch>,
     #[serde(skip)]
     ancestor_map: DemeMap,
-    #[serde(default = "DemeDefaultsInput::default")]
+    #[serde(default = "DemeDefaults::default")]
     #[serde(skip_serializing)]
-    defaults: DemeDefaultsInput,
+    defaults: DemeDefaults,
 }
 
 impl PartialEq for DemeData {
@@ -1608,23 +1608,7 @@ struct TopLevelDemeDefaults {
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct DemeDefaultsInput {
-    #[serde(flatten)]
-    defaults: DemeDefaults,
-}
-
-impl std::ops::Deref for DemeDefaultsInput {
-    type Target = DemeDefaults;
-
-    fn deref(&self) -> &Self::Target {
-        &self.defaults
-    }
-}
-
-#[derive(Clone, Default, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct DemeDefaults {
-    #[serde(default = "Epoch::default")]
     epoch: Epoch,
 }
 


### PR DESCRIPTION
Remove need for a wrapper/holder type for deme-level defaults during serde operations.
