### PR TITLE
refactor newtypes from f64

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,6 +2,12 @@
 
 macro_rules! impl_newtype_traits {
     ($type: ty) => {
+        impl From<f64> for $type {
+            fn from(value: f64) -> Self {
+                Self(value)
+            }
+        }
+
         impl From<$type> for f64 {
             fn from(value: $type) -> f64 {
                 value.0

--- a/tests/test_graph.rs
+++ b/tests/test_graph.rs
@@ -10,19 +10,14 @@ struct ExpectedMigration {
 }
 
 impl ExpectedMigration {
-    fn new<
-        N: ToString,
-        M: TryInto<MigrationRate, Error = demes::DemesError>,
-        S: Into<Time>,
-        E: Into<Time>,
-    >(
+    fn new<N: ToString, M: Into<MigrationRate>, S: Into<Time>, E: Into<Time>>(
         source: N,
         dest: N,
         rate: M,
         start_time: S,
         end_time: E,
     ) -> Result<Self, demes::DemesError> {
-        let rate = rate.try_into()?;
+        let rate = rate.into();
         let start_time = start_time.into();
         let end_time = end_time.into();
         Ok(Self {


### PR DESCRIPTION
See issue #114

This PR:

* replaces TryFrom<f64> with From<f64> for all new types.
  This change moves errors from YamlError to the expected "level" 
  of the graph, which is more understandable.
* Fixes a bug in cloning/selfing rate resolution discovered while
  making the change noted above.
