### PR TITLE
Add demes-forward

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
             cargo test --all-features
             cargo test --all-features --examples
+      - name: test demes-forward
+        working-directory: demes-forward
+        run: |
+          cargo test
 
   fmt:
     name: rust fmt

--- a/demes-forward/Cargo.toml
+++ b/demes-forward/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 demes = { version =  "~0.2", path =  ".." }
+thiserror = "~1"

--- a/demes-forward/Cargo.toml
+++ b/demes-forward/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "demes-forward"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+demes = { version =  "~0.2", path =  ".." }

--- a/demes-forward/src/error.rs
+++ b/demes-forward/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DemesForwardError {
+    #[error("{0:?}")]
+    DemesError(demes::DemesError),
+}
+
+impl From<demes::DemesError> for DemesForwardError {
+    fn from(error: demes::DemesError) -> Self {
+        Self::DemesError(error)
+    }
+}

--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -6,7 +6,7 @@ impl ForwardGraph {
     pub fn new(
         graph: demes::Graph,
         rounding: Option<demes::RoundTimeToInteger>,
-    ) -> Result<Self, demes::DemesError> {
+    ) -> Result<Self, crate::DemesForwardError> {
         let graph = match rounding {
             Some(r) => graph.to_integer_generations(r)?,
             None => graph.to_generations()?,
@@ -56,10 +56,8 @@ demes:
     }
 
     #[test]
-    #[should_panic]
     fn invalid_conversion_error() {
         let demes_graph = two_epoch_model_invalid_conversion_to_generations();
-        // let graph = ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64)).unwrap();
         if let Err(crate::DemesForwardError::DemesError(demes::DemesError::EpochError(_))) =
             ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64))
         {

--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -7,6 +7,10 @@ impl ForwardGraph {
         graph: demes::Graph,
         rounding: Option<demes::RoundTimeToInteger>,
     ) -> Result<Self, demes::DemesError> {
+        let graph = match rounding {
+            Some(r) => graph.to_integer_generations(r)?,
+            None => graph.to_generations()?,
+        };
         Ok(Self { graph })
     }
 }
@@ -55,17 +59,6 @@ demes:
     #[should_panic]
     fn invalid_conversion_error() {
         let demes_graph = two_epoch_model_invalid_conversion_to_generations();
-        let g = demes_graph
-            .to_integer_generations(demes::RoundTimeToInteger::F64)
-            .unwrap();
-        for d in g.demes() {
-            for e in d.start_times() {
-                println!("start time: {}", e);
-            }
-            for e in d.end_times() {
-                println!("end time: {}", e);
-            }
-        }
-        // let graph = ForwardGraph::new(demes_graph, None).unwrap();
+        let graph = ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64)).unwrap();
     }
 }

--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -60,10 +60,10 @@ demes:
             .unwrap();
         for d in g.demes() {
             for e in d.start_times() {
-                println!("{}", e);
+                println!("start time: {}", e);
             }
             for e in d.end_times() {
-                println!("{}", e);
+                println!("end time: {}", e);
             }
         }
         // let graph = ForwardGraph::new(demes_graph, None).unwrap();

--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -58,11 +58,12 @@ demes:
     #[test]
     fn invalid_conversion_error() {
         let demes_graph = two_epoch_model_invalid_conversion_to_generations();
-        if let Err(crate::DemesForwardError::DemesError(demes::DemesError::EpochError(_))) =
-            ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64))
-        {
-        } else {
-            panic!("expected DemesError::EpochError!");
-        }
+        let result = ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64));
+        assert!(matches!(
+            result,
+            Err(crate::DemesForwardError::DemesError(
+                demes::DemesError::EpochError(_)
+            ))
+        ));
     }
 }

--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -1,0 +1,71 @@
+pub struct ForwardGraph {
+    graph: demes::Graph,
+}
+
+impl ForwardGraph {
+    pub fn new(
+        graph: demes::Graph,
+        rounding: Option<demes::RoundTimeToInteger>,
+    ) -> Result<Self, demes::DemesError> {
+        Ok(Self { graph })
+    }
+}
+
+#[cfg(test)]
+mod graph_tests {
+    use super::*;
+
+    fn two_epoch_model() -> demes::Graph {
+        let yaml = "
+time_units: generations
+demes:
+ - name: A
+   epochs:
+    - start_size: 200
+      end_time: 50
+    - start_size: 100
+";
+        demes::loads(yaml).unwrap()
+    }
+
+    fn two_epoch_model_invalid_conversion_to_generations() -> demes::Graph {
+        let yaml = "
+time_units: years
+description:
+  50/1000 = 0.05, rounds to zero.
+  Thus, the second epoch has length zero.
+generation_time: 1000.0
+demes:
+ - name: A
+   epochs:
+    - start_size: 200
+      end_time: 50
+    - start_size: 100
+";
+        demes::loads(yaml).unwrap()
+    }
+
+    #[test]
+    fn initialize_graph() {
+        let demes_graph = two_epoch_model();
+        let graph = ForwardGraph::new(demes_graph, None).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_conversion_error() {
+        let demes_graph = two_epoch_model_invalid_conversion_to_generations();
+        let g = demes_graph
+            .to_integer_generations(demes::RoundTimeToInteger::F64)
+            .unwrap();
+        for d in g.demes() {
+            for e in d.start_times() {
+                println!("{}", e);
+            }
+            for e in d.end_times() {
+                println!("{}", e);
+            }
+        }
+        // let graph = ForwardGraph::new(demes_graph, None).unwrap();
+    }
+}

--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -52,7 +52,7 @@ demes:
     #[test]
     fn initialize_graph() {
         let demes_graph = two_epoch_model();
-        let graph = ForwardGraph::new(demes_graph, None).unwrap();
+        ForwardGraph::new(demes_graph, None).unwrap();
     }
 
     #[test]
@@ -61,7 +61,6 @@ demes:
         if let Err(crate::DemesForwardError::DemesError(demes::DemesError::EpochError(_))) =
             ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64))
         {
-            ()
         } else {
             panic!("expected DemesError::EpochError!");
         }

--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -59,6 +59,13 @@ demes:
     #[should_panic]
     fn invalid_conversion_error() {
         let demes_graph = two_epoch_model_invalid_conversion_to_generations();
-        let graph = ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64)).unwrap();
+        // let graph = ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64)).unwrap();
+        if let Err(crate::DemesForwardError::DemesError(demes::DemesError::EpochError(_))) =
+            ForwardGraph::new(demes_graph, Some(demes::RoundTimeToInteger::F64))
+        {
+            ()
+        } else {
+            panic!("expected DemesError::EpochError!");
+        }
     }
 }

--- a/demes-forward/src/lib.rs
+++ b/demes-forward/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/demes-forward/src/lib.rs
+++ b/demes-forward/src/lib.rs
@@ -1,8 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}
+mod graph;

--- a/demes-forward/src/lib.rs
+++ b/demes-forward/src/lib.rs
@@ -1,1 +1,4 @@
+mod error;
 mod graph;
+
+pub use error::DemesForwardError;


### PR DESCRIPTION
Add demes-forward, which is intended to:

1. Store a demes::Graph with time_units: generations.
2. Given a value representing time moving *forwards*,
   figure out where we are in the Graph.
