### PR TITLE
fix clippy lint

### DIFF
--- a/src/specification.rs
+++ b/src/specification.rs
@@ -2336,8 +2336,25 @@ impl DemeDefaults {
 /// ```
 #[derive(Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Metadata {
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "require_non_empty_metadata")]
     metadata: std::collections::BTreeMap<String, serde_yaml::Value>,
+}
+
+fn require_non_empty_metadata<'de, D>(
+    deserializer: D,
+) -> Result<std::collections::BTreeMap<String, serde_yaml::Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let buf = std::collections::BTreeMap::<String, serde_yaml::Value>::deserialize(deserializer)?;
+
+    if !buf.is_empty() {
+        Ok(buf)
+    } else {
+        Err(serde::de::Error::custom(
+            "metadata: cannot be an empty mapping".to_string(),
+        ))
+    }
 }
 
 impl Metadata {

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -2532,7 +2532,7 @@ impl Graph {
         let mut rv = DemeMap::default();
 
         for deme in &self.demes {
-            if rv.contains_key(&deme.name().to_string()) {
+            if rv.contains_key(deme.name().deref()) {
                 return Err(DemesError::DemeError(format!(
                     "duplicate deme name: {}",
                     deme.name(),


### PR DESCRIPTION
- pin to serde_yaml version causing a regression
- fix: Metadata now errors on empty mapping
- fix: fix clippy::unnecessary_to_owned lint
