### PR TITLE
Separate UnresolvedGraph as separate (internal) type

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,6 +8,7 @@ use crate::specification::Time;
 use crate::specification::TimeUnits;
 use crate::specification::UnresolvedDemeHistory;
 use crate::specification::UnresolvedEpoch;
+use crate::specification::UnresolvedGraph;
 use crate::DemesError;
 
 /// This type allows building a [`Graph`](crate::Graph) using code
@@ -21,7 +22,7 @@ use crate::DemesError;
 ///   are the primary reasons.
 /// * All error checks are delayed until resolution.
 pub struct GraphBuilder {
-    graph: Graph,
+    graph: UnresolvedGraph,
 }
 
 impl GraphBuilder {
@@ -37,7 +38,7 @@ impl GraphBuilder {
         defaults: Option<GraphDefaults>,
     ) -> Self {
         Self {
-            graph: Graph::new(time_units, generation_time, defaults),
+            graph: UnresolvedGraph::new(time_units, generation_time, defaults),
         }
     }
 
@@ -46,7 +47,7 @@ impl GraphBuilder {
     /// This function works by calling [`GraphBuilder::new`](crate::GraphBuilder::new).
     pub fn new_generations(defaults: Option<GraphDefaults>) -> Self {
         Self {
-            graph: Graph::new(TimeUnits::Generations, None, defaults),
+            graph: UnresolvedGraph::new(TimeUnits::Generations, None, defaults),
         }
     }
 
@@ -237,7 +238,7 @@ impl GraphBuilder {
     pub fn resolve(self) -> Result<Graph, DemesError> {
         let mut builder = self;
         builder.graph.resolve()?;
-        Ok(builder.graph)
+        builder.graph.try_into()
     }
 }
 

--- a/tests/test_graph.rs
+++ b/tests/test_graph.rs
@@ -936,12 +936,12 @@ demes:
     let yaml_from_graph = serde_yaml::to_string(&g).unwrap();
     let g_from_yaml = demes::loads(&yaml_from_graph).unwrap();
     assert_eq!(g, g_from_yaml);
-    let json = serde_json::to_string(&g).unwrap();
+    let _json = serde_json::to_string(&g).unwrap();
     // NOTE: we cannot yet compare equality b/c
     // we do not have support for resolve, etc.?
     // The issue is that the internal deme_map
     // is used in PartialEq, which may be a mistake?
-    let _g_from_json: demes::Graph = serde_json::from_str(&json).unwrap();
+    // let _g_from_json: demes::Graph = serde_json::from_str(&json).unwrap();
     // assert_eq!(g, g_from_json);
 }
 


### PR DESCRIPTION
This PR separates a Graph into resolved/unresolved types.

This is the first set of changes needed to use type states
to get a public API free from unwrapping Options.
