### PR TITLE
refactor: remove type name from impl Display for newtypes.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -63,7 +63,7 @@ macro_rules! impl_newtype_traits {
 
         impl std::fmt::Display for $type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}({})", stringify!($type), self.0)
+                write!(f, "{}", self.0)
             }
         }
     };

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -2686,7 +2686,7 @@ mod tests {
     fn test_display() {
         let t = Time::from(1.0);
         let f = format!("{}", t);
-        assert!(f.contains("Time("));
+        assert_eq!(f, String::from("1"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #198
