### PR TITLE
reject non-integer deme sizes when constructing ForwardGraph

### DIFF
--- a/demes-forward/src/graph.rs
+++ b/demes-forward/src/graph.rs
@@ -347,6 +347,15 @@ impl ForwardGraph {
         burnin_time: F,
         rounding: Option<demes::RoundTimeToInteger>,
     ) -> Result<Self, crate::DemesForwardError> {
+        if let Some((name, index)) = graph.has_non_integer_sizes() {
+            let deme = graph.get_deme_from_name(name).unwrap();
+            let epoch = deme.epochs()[index];
+            for i in [f64::from(epoch.start_size()), f64::from(epoch.end_size())] {
+                if i.is_finite() && i.fract() != 0.0 {
+                    return Err(DemesForwardError::InvalidDemeSize(i.into()));
+                }
+            }
+        }
         let burnin_time = burnin_time.into();
         if !burnin_time.valid() {
             return Err(DemesForwardError::TimeError(format!(

--- a/demes-forward/tests/tests.rs
+++ b/demes-forward/tests/tests.rs
@@ -343,3 +343,47 @@ demes:
     let last = last_time.last.expect("expected Some(time) for last");
     assert_eq!(last, 150.0.into());
 }
+
+#[test]
+fn test_reject_non_integer_start_size() {
+    let yaml = "
+time_units: generations
+demes:
+- name: deme1
+  start_time: .inf
+  epochs:
+  - {end_size: 100.0, end_time: 8000.0, start_size: 100.0}
+  - {end_size: 100.0, end_time: 4000.0, start_size: 99.99000049998334}
+  - {end_size: 100, end_time: 0, start_size: 100.0}
+migrations: []
+";
+    let demes_graph = demes::loads(yaml).unwrap();
+    assert!(demes_forward::ForwardGraph::new(
+        demes_graph,
+        100,
+        Some(demes::RoundTimeToInteger::F64)
+    )
+    .is_err());
+}
+
+#[test]
+fn test_reject_non_integer_end_size() {
+    let yaml = "
+time_units: generations
+demes:
+- name: deme1
+  start_time: .inf
+  epochs:
+  - {end_size: 100.0, end_time: 8000.0, start_size: 100.0}
+  - {end_size: 99.99000049998334, end_time: 4000.0, start_size: 100.0}
+  - {end_size: 100, end_time: 0, start_size: 100.0}
+migrations: []
+";
+    let demes_graph = demes::loads(yaml).unwrap();
+    assert!(demes_forward::ForwardGraph::new(
+        demes_graph,
+        100,
+        Some(demes::RoundTimeToInteger::F64)
+    )
+    .is_err());
+}


### PR DESCRIPTION
- DemesForwardError marked non_exhaustive
- move to rejecting non-integer pop sizes
