### PR TITLE
Introduce input types to allow TryFrom<f64> for newtypes.

### DIFF
--- a/demes-forward/examples/iterate_gutenkunst.rs
+++ b/demes-forward/examples/iterate_gutenkunst.rs
@@ -145,7 +145,7 @@ fn do_work(burnin: i32) -> Result<()> {
         generation_time,
         graph.time_units()
     );
-    let mut most_ancient_finite_epoch_start_time = demes::Time::from(0.0);
+    let mut most_ancient_finite_epoch_start_time = demes::Time::try_from(0.0).unwrap();
     for deme in graph.demes() {
         for epoch in deme.epochs() {
             let start_time = epoch.start_time();

--- a/demes-forward/src/current_size.rs
+++ b/demes-forward/src/current_size.rs
@@ -1,0 +1,55 @@
+use crate::DemesForwardError;
+
+/// The current size of a deme.
+///
+/// Unlike [`demes::DemeSize`], this type
+/// allows for values of 0.0, which means
+/// that there are no individuals in the
+/// deme at the current time.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub struct CurrentSize(f64);
+
+impl TryFrom<f64> for CurrentSize {
+    type Error = DemesForwardError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        if value.is_sign_positive() && value.is_finite() {
+            Ok(Self(value))
+        } else {
+            Err(DemesForwardError::InvalidDemeSize(value))
+        }
+    }
+}
+
+impl TryFrom<demes::DemeSize> for CurrentSize {
+    type Error = DemesForwardError;
+
+    fn try_from(value: demes::DemeSize) -> Result<Self, Self::Error> {
+        Self::try_from(f64::from(value))
+    }
+}
+
+impl PartialEq<CurrentSize> for f64 {
+    fn eq(&self, other: &CurrentSize) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl PartialEq<f64> for CurrentSize {
+    fn eq(&self, other: &f64) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<CurrentSize> for f64 {
+    fn partial_cmp(&self, other: &CurrentSize) -> Option<std::cmp::Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
+impl PartialOrd<f64> for CurrentSize {
+    fn partial_cmp(&self, other: &f64) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}

--- a/demes-forward/src/error.rs
+++ b/demes-forward/src/error.rs
@@ -17,7 +17,7 @@ pub enum DemesForwardError {
     /// arising during application of size change
     /// functions.
     #[error("{0:?}")]
-    InvalidDemeSize(demes::DemeSize),
+    InvalidDemeSize(f64),
     /// Errors related to invalid internal states.
     /// In general, this error indicates a bug
     /// that should be reported.

--- a/demes-forward/src/lib.rs
+++ b/demes-forward/src/lib.rs
@@ -23,10 +23,12 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 
+mod current_size;
 mod error;
 mod graph;
 mod time;
 
+pub use current_size::CurrentSize;
 pub use demes;
 pub use error::DemesForwardError;
 pub use graph::ForwardGraph;

--- a/demes-forward/src/time.rs
+++ b/demes-forward/src/time.rs
@@ -88,7 +88,7 @@ impl ModelTime {
             Ok(Some(
                 (self.burnin_generation + self.model_duration - 1.0 - time.value()
                     + self.minimum_epoch_end_time)
-                    .into(),
+                    .try_into()?,
             ))
         } else {
             Ok(None)
@@ -100,7 +100,7 @@ impl ModelTime {
     }
 }
 
-fn get_model_start_time(graph: &demes::Graph) -> demes::Time {
+fn get_model_start_time(graph: &demes::Graph) -> Result<demes::Time, demes::DemesError> {
     // first end time of all demes with start time of infinity
     let mut times = graph
         .demes()
@@ -138,7 +138,7 @@ fn get_model_start_time(graph: &demes::Graph) -> demes::Time {
 
     debug_assert!(!times.is_empty());
 
-    demes::Time::from(f64::from(*times.iter().max().unwrap()) + 1.0)
+    demes::Time::try_from(f64::from(*times.iter().max().unwrap()) + 1.0)
 }
 
 impl ModelTime {
@@ -149,7 +149,7 @@ impl ModelTime {
         // The logic here is lifted from the fwdpy11
         // demes import code by Aaron Ragsdale.
 
-        let model_start_time = get_model_start_time(graph);
+        let model_start_time = get_model_start_time(graph)?;
 
         let most_recent_deme_end = graph
             .demes()
@@ -189,7 +189,9 @@ impl ModelTime {
         };
         TimeIterator {
             current_time,
-            final_time: (self.burnin_generation() + self.model_duration()).into(),
+            final_time: (self.burnin_generation() + self.model_duration())
+                .try_into()
+                .unwrap(),
         }
     }
 }

--- a/demes-forward/tests/tests.rs
+++ b/demes-forward/tests/tests.rs
@@ -1,4 +1,5 @@
 use demes_forward::demes;
+use demes_forward::CurrentSize;
 
 #[derive(Debug)]
 struct ModelFirstLast {
@@ -410,7 +411,7 @@ demes:
   - {start_size: 2, end_time: 50}
   - {start_size: 3, end_time: 10}
 ";
-    let validate_sizes = |s: &[demes::DemeSize], expected: &[f64]| {
+    let validate_sizes = |s: &[CurrentSize], expected: &[f64]| {
         for (i, j) in s.iter().zip(expected.iter()) {
             assert_eq!(i, j);
         }
@@ -462,7 +463,10 @@ demes:
     assert!(graph.size_at(1, 0.0).unwrap().is_none());
     assert!(graph.size_at(0, 0.0).is_ok());
     assert!(graph.size_at(0, 0.0).unwrap().is_some());
-    assert_eq!(graph.size_at(0, 0.0).unwrap(), Some(10.0.into()));
+    assert_eq!(
+        graph.size_at(0, 0.0).unwrap(),
+        Some(10.0.try_into().unwrap())
+    );
 
     // Infinity ago is prior to start of "burn in"
     assert!(graph.size_at(1, f64::INFINITY).is_ok());

--- a/demes/src/builder.rs
+++ b/demes/src/builder.rs
@@ -7,10 +7,10 @@ use crate::specification::UnresolvedDemeHistory;
 use crate::specification::UnresolvedEpoch;
 use crate::specification::UnresolvedGraph;
 use crate::DemesError;
-use crate::GenerationTime;
-use crate::MigrationRate;
-use crate::Proportion;
-use crate::Time;
+use crate::InputGenerationTime;
+use crate::InputMigrationRate;
+use crate::InputProportion;
+use crate::InputTime;
 use crate::TimeUnits;
 
 #[derive(Error, Debug)]
@@ -44,7 +44,7 @@ impl GraphBuilder {
     /// [`Graph`](crate::Graph).
     pub fn new(
         time_units: TimeUnits,
-        generation_time: Option<GenerationTime>,
+        generation_time: Option<InputGenerationTime>,
         defaults: Option<GraphDefaults>,
     ) -> Self {
         Self {
@@ -68,7 +68,7 @@ impl GraphBuilder {
     /// # Examples
     ///
     /// ```
-    /// let start_size = demes::DemeSize::from(100.);
+    /// let start_size = demes::InputDemeSize::from(100.);
     /// let epoch = demes::UnresolvedEpoch{start_size: Some(start_size), ..Default::default()};
     /// let history = demes::UnresolvedDemeHistory::default();
     /// let mut b = demes::GraphBuilder::new_generations(None);
@@ -93,7 +93,7 @@ impl GraphBuilder {
     /// # Examples
     ///
     /// ```
-    /// let start_size = demes::DemeSize::from(100.);
+    /// let start_size = demes::InputDemeSize::from(100.);
     /// let epoch = demes::UnresolvedEpoch{start_size: Some(start_size), ..Default::default()};
     /// let history = demes::UnresolvedDemeHistory::default();
     /// let mut b = demes::GraphBuilder::new_generations(None);
@@ -101,7 +101,7 @@ impl GraphBuilder {
     /// b.add_deme("B", vec![epoch], history, Some("this is deme B"));
     /// b.add_asymmetric_migration(Some("A"),
     ///                            Some("B"),
-    ///                            Some(demes::MigrationRate::from(1e-4)),
+    ///                            Some(1e-4.into()),
     ///                            None, // Using None for the times
     ///                                  // will mean continuous migration for the
     ///                                  // duration for which the demes coexist.
@@ -112,9 +112,9 @@ impl GraphBuilder {
         &mut self,
         source: Option<S>,
         dest: Option<D>,
-        rate: Option<MigrationRate>,
-        start_time: Option<Time>,
-        end_time: Option<Time>,
+        rate: Option<InputMigrationRate>,
+        start_time: Option<InputTime>,
+        end_time: Option<InputTime>,
     ) {
         self.add_migration::<String, _, _>(None, source, dest, rate, start_time, end_time);
     }
@@ -123,14 +123,14 @@ impl GraphBuilder {
     ///
     /// # Examples
     /// ```
-    /// let start_size = demes::DemeSize::from(100.);
+    /// let start_size = demes::InputDemeSize::from(100.);
     /// let epoch = demes::UnresolvedEpoch{start_size: Some(start_size), ..Default::default()};
     /// let history = demes::UnresolvedDemeHistory::default();
     /// let mut b = demes::GraphBuilder::new_generations(None);
     /// b.add_deme("A", vec![epoch], history.clone(), Some("this is deme A"));
     /// b.add_deme("B", vec![epoch], history, Some("this is deme B"));
     /// b.add_symmetric_migration(Some(&["A", "B"]),
-    ///                           Some(demes::MigrationRate::from(1e-4)),
+    ///                           Some(1e-4.into()),
     ///                           None, // Using None for the times
     ///                                 // will mean continuous migration for the
     ///                                 // duration for which the demes coexist.
@@ -140,9 +140,9 @@ impl GraphBuilder {
     pub fn add_symmetric_migration<D: ToString>(
         &mut self,
         demes: Option<&[D]>,
-        rate: Option<MigrationRate>,
-        start_time: Option<Time>,
-        end_time: Option<Time>,
+        rate: Option<InputMigrationRate>,
+        start_time: Option<InputTime>,
+        end_time: Option<InputTime>,
     ) {
         self.add_migration::<_, String, String>(demes, None, None, rate, start_time, end_time);
     }
@@ -160,7 +160,7 @@ impl GraphBuilder {
     /// ## Adding an asymmetric migration
     ///
     /// ```
-    /// let start_size = demes::DemeSize::from(100.);
+    /// let start_size = demes::InputDemeSize::from(100.);
     /// let epoch = demes::UnresolvedEpoch{start_size: Some(start_size), ..Default::default()};
     /// let history = demes::UnresolvedDemeHistory::default();
     /// let mut b = demes::GraphBuilder::new_generations(None);
@@ -169,7 +169,7 @@ impl GraphBuilder {
     /// b.add_migration::<String, _, _>(None,
     ///                   Some("A"),
     ///                   Some("B"),
-    ///                   Some(demes::MigrationRate::from(1e-4)),
+    ///                   Some(1e-4.into()),
     ///                   None, // Using None for the times
     ///                         // will mean continuous migration for the
     ///                         // duration for which the demes coexist.
@@ -180,7 +180,7 @@ impl GraphBuilder {
     /// ## Adding a symmetric migration
     ///
     /// ```
-    /// let start_size = demes::DemeSize::from(100.);
+    /// let start_size = demes::InputDemeSize::from(100.);
     /// let epoch = demes::UnresolvedEpoch{start_size: Some(start_size), ..Default::default()};
     /// let history = demes::UnresolvedDemeHistory::default();
     /// let mut b = demes::GraphBuilder::new_generations(None);
@@ -189,7 +189,7 @@ impl GraphBuilder {
     /// b.add_migration::<_, String, String>(Some(&["A", "B"]),
     ///                   None,
     ///                   None,
-    ///                   Some(demes::MigrationRate::from(1e-4)),
+    ///                   Some(1e-4.into()),
     ///                   None, // Using None for the times
     ///                         // will mean continuous migration for the
     ///                         // duration for which the demes coexist.
@@ -201,9 +201,9 @@ impl GraphBuilder {
         demes: Option<&[D]>,
         source: Option<S>,
         dest: Option<E>,
-        rate: Option<MigrationRate>,
-        start_time: Option<Time>,
-        end_time: Option<Time>,
+        rate: Option<InputMigrationRate>,
+        start_time: Option<InputTime>,
+        end_time: Option<InputTime>,
     ) {
         let demes = demes.map(|value| value.iter().map(|v| v.to_string()).collect::<Vec<_>>());
         let source = source.map(|value| value.to_string());
@@ -217,7 +217,7 @@ impl GraphBuilder {
     /// # Examples
     ///
     /// ```
-    /// let start_size = demes::DemeSize::from(100.);
+    /// let start_size = demes::InputDemeSize::from(100.);
     /// let epoch = demes::UnresolvedEpoch{start_size: Some(start_size), ..Default::default()};
     /// let history = demes::UnresolvedDemeHistory::default();
     /// let mut b = demes::GraphBuilder::new_generations(None);
@@ -225,16 +225,16 @@ impl GraphBuilder {
     /// b.add_deme("B", vec![epoch], history, Some("this is deme B"));
     /// b.add_pulse(Some(&["A"]),
     ///             Some("B"),
-    ///             Some(demes::Time::from(50.0)),
-    ///             Some(vec![demes::Proportion::from(0.5)]));
+    ///             Some(demes::InputTime::from(50.0)),
+    ///             Some(vec![demes::InputProportion::from(0.5)]));
     /// b.resolve().unwrap();
     /// ```
     pub fn add_pulse(
         &mut self,
         sources: Option<&[&str]>,
         dest: Option<&str>,
-        time: Option<Time>,
-        proportions: Option<Vec<Proportion>>,
+        time: Option<InputTime>,
+        proportions: Option<Vec<InputProportion>>,
     ) {
         let sources = sources.map(|value| value.iter().map(|v| v.to_string()).collect::<Vec<_>>());
         let dest = dest.map(|value| value.to_string());
@@ -297,7 +297,7 @@ impl GraphBuilder {
 mod tests {
     use super::*;
     use crate::specification::DemeDefaults;
-    use crate::DemeSize;
+    use crate::InputDemeSize;
 
     #[test]
     #[should_panic]
@@ -310,7 +310,7 @@ mod tests {
     fn add_deme_with_epochs() {
         let mut b = GraphBuilder::new_generations(Some(GraphDefaults::default()));
         let edata = UnresolvedEpoch {
-            start_size: Some(DemeSize::from(100.0)),
+            start_size: Some(InputDemeSize::from(100.0)),
             ..Default::default()
         };
         b.add_deme("CEU", vec![edata], UnresolvedDemeHistory::default(), None);
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn use_proportion_for_proportions() {
-        let p = Proportion::from(0.5);
+        let p = InputProportion::from(0.5);
         let _ = UnresolvedDemeHistory {
             proportions: Some(vec![p, p]),
             ..Default::default()
@@ -330,7 +330,7 @@ mod tests {
     fn builder_deme_defaults() {
         let defaults = DemeDefaults {
             epoch: UnresolvedEpoch {
-                end_size: Some(DemeSize::from(100.)),
+                end_size: Some(InputDemeSize::from(100.)),
                 ..Default::default()
             },
         };

--- a/demes/src/cloning_rate.rs
+++ b/demes/src/cloning_rate.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// The cloning rate of an [`Epoch`](crate::Epoch).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[repr(transparent)]
-#[serde(from = "f64")]
+#[serde(try_from = "f64")]
 pub struct CloningRate(f64);
 
 impl CloningRate {
@@ -22,16 +22,53 @@ impl CloningRate {
     }
 }
 
+impl TryFrom<f64> for CloningRate {
+    type Error = DemesError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        let rv = Self(value);
+        rv.validate(DemesError::ValueError)?;
+        Ok(rv)
+    }
+}
+
 impl_newtype_traits!(CloningRate);
 
 impl Default for CloningRate {
     fn default() -> Self {
-        Self::from(0.0)
+        Self::try_from(0.0).unwrap()
     }
 }
 
 impl Validate for CloningRate {
     fn validate<F: FnOnce(String) -> DemesError>(&self, err: F) -> Result<(), DemesError> {
         self.validate(err)
+    }
+}
+
+/// Input value for [`CloningRate`], used when loading or building graphs.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, PartialOrd)]
+#[repr(transparent)]
+#[serde(from = "f64")]
+pub struct InputCloningRate(f64);
+
+impl From<f64> for InputCloningRate {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl TryFrom<InputCloningRate> for CloningRate {
+    type Error = DemesError;
+
+    fn try_from(value: InputCloningRate) -> Result<Self, Self::Error> {
+        let rv = Self(value.0);
+        rv.validate(DemesError::ValueError)?;
+        Ok(rv)
+    }
+}
+
+impl Default for InputCloningRate {
+    fn default() -> Self {
+        Self::from(0.0)
     }
 }

--- a/demes/src/error.rs
+++ b/demes/src/error.rs
@@ -50,6 +50,9 @@ pub enum DemesError {
     #[error("{0:?}")]
     /// Errors coming from `serde_json`.
     JsonError(serde_json::Error),
+    /// Errors related to low-level types
+    #[error("{0:?}")]
+    ValueError(String),
 }
 
 impl From<serde_yaml::Error> for DemesError {

--- a/demes/src/lib.rs
+++ b/demes/src/lib.rs
@@ -55,12 +55,12 @@ mod traits;
 use std::io::Read;
 
 pub use builder::GraphBuilder;
-pub use cloning_rate::CloningRate;
-pub use deme_size::DemeSize;
+pub use cloning_rate::{CloningRate, InputCloningRate};
+pub use deme_size::{DemeSize, InputDemeSize};
 pub use error::DemesError;
-pub use migration_rate::MigrationRate;
-pub use proportion::Proportion;
-pub use selfing_rate::SelfingRate;
+pub use migration_rate::{InputMigrationRate, MigrationRate};
+pub use proportion::{InputProportion, Proportion};
+pub use selfing_rate::{InputSelfingRate, SelfingRate};
 pub use specification::*;
 pub use time::*;
 

--- a/demes/src/macros.rs
+++ b/demes/src/macros.rs
@@ -2,12 +2,6 @@
 
 macro_rules! impl_newtype_traits {
     ($type: ty) => {
-        impl From<f64> for $type {
-            fn from(value: f64) -> Self {
-                Self(value)
-            }
-        }
-
         impl From<$type> for f64 {
             fn from(value: $type) -> f64 {
                 value.0

--- a/demes/src/migration_rate.rs
+++ b/demes/src/migration_rate.rs
@@ -12,8 +12,38 @@ use serde::{Deserialize, Serialize};
 /// * [`GraphBuilder::add_asymmetric_migration`](crate::GraphBuilder::add_asymmetric_migration)
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[repr(transparent)]
-#[serde(from = "f64")]
+#[serde(try_from = "f64")]
 pub struct MigrationRate(f64);
+
+impl TryFrom<f64> for MigrationRate {
+    type Error = DemesError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        let rv = Self(value);
+        rv.validate(DemesError::MigrationError)?;
+        Ok(rv)
+    }
+}
+
+/// Input value for [`MigrationRate`], used when loading or building graphs.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[repr(transparent)]
+#[serde(from = "f64")]
+pub struct InputMigrationRate(f64);
+
+impl From<f64> for InputMigrationRate {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl TryFrom<InputMigrationRate> for MigrationRate {
+    type Error = DemesError;
+
+    fn try_from(value: InputMigrationRate) -> Result<Self, Self::Error> {
+        Self::try_from(value.0)
+    }
+}
 
 impl MigrationRate {
     fn validate<F>(&self, f: F) -> Result<(), DemesError>
@@ -31,11 +61,11 @@ impl MigrationRate {
 
 impl_newtype_traits!(MigrationRate);
 
-impl Default for MigrationRate {
-    fn default() -> Self {
-        Self::from(0.0)
-    }
-}
+//impl Default for MigrationRate {
+//    fn default() -> Self {
+//        Self(0.0)
+//    }
+//}
 
 impl Validate for MigrationRate {
     fn validate<F: FnOnce(String) -> DemesError>(&self, err: F) -> Result<(), DemesError> {

--- a/demes/src/selfing_rate.rs
+++ b/demes/src/selfing_rate.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// The selfing rate of an [`Epoch`](crate::Epoch).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[repr(transparent)]
-#[serde(from = "f64")]
+#[serde(try_from = "f64")]
 pub struct SelfingRate(f64);
 
 impl SelfingRate {
@@ -24,14 +24,51 @@ impl SelfingRate {
 
 impl_newtype_traits!(SelfingRate);
 
+impl TryFrom<f64> for SelfingRate {
+    type Error = DemesError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        let rv = Self(value);
+        rv.validate(DemesError::ValueError)?;
+        Ok(rv)
+    }
+}
+
 impl Default for SelfingRate {
     fn default() -> Self {
-        Self::from(0.0)
+        Self::try_from(0.0).unwrap()
     }
 }
 
 impl Validate for SelfingRate {
     fn validate<F: FnOnce(String) -> DemesError>(&self, err: F) -> Result<(), DemesError> {
         self.validate(err)
+    }
+}
+
+/// Input value for [`SelfingRate`], used when loading or building graphs.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, PartialOrd)]
+#[repr(transparent)]
+#[serde(from = "f64")]
+pub struct InputSelfingRate(f64);
+
+impl From<f64> for InputSelfingRate {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl TryFrom<InputSelfingRate> for SelfingRate {
+    type Error = DemesError;
+
+    fn try_from(value: InputSelfingRate) -> Result<Self, Self::Error> {
+        let rv = Self(value.0);
+        rv.validate(DemesError::ValueError)?;
+        Ok(rv)
+    }
+}
+
+impl Default for InputSelfingRate {
+    fn default() -> Self {
+        Self::from(0.0)
     }
 }

--- a/demes/tests/test_builder.rs
+++ b/demes/tests/test_builder.rs
@@ -1,9 +1,9 @@
-use demes::DemeSize;
-use demes::GenerationTime;
 use demes::GraphBuilder;
 use demes::GraphDefaults;
-use demes::Proportion;
-use demes::Time;
+use demes::InputDemeSize;
+use demes::InputGenerationTime;
+use demes::InputProportion;
+use demes::InputTime;
 use demes::TimeUnits;
 use demes::TopLevelDemeDefaults;
 use demes::UnresolvedDemeHistory;
@@ -32,24 +32,24 @@ demes:
         pulse: UnresolvedPulse {
             sources: Some(vec!["A".to_string()]),
             dest: Some("B".to_string()),
-            proportions: Some(vec![Proportion::try_from(0.25).unwrap()]),
-            time: Some(Time::try_from(100.).unwrap()),
+            proportions: Some(vec![InputProportion::from(0.25)]),
+            time: Some(InputTime::from(100.)),
         },
         ..Default::default()
     };
 
     let epochs_a = UnresolvedEpoch {
-        start_size: Some(DemeSize::try_from(100.0).unwrap()),
+        start_size: Some(InputDemeSize::from(100.0)),
         ..Default::default()
     };
     let epochs_b = UnresolvedEpoch {
-        start_size: Some(DemeSize::try_from(250.0).unwrap()),
+        start_size: Some(InputDemeSize::from(250.0)),
         ..Default::default()
     };
 
     let mut builder = GraphBuilder::new(
         TimeUnits::Years,
-        Some(GenerationTime::from(25.0)),
+        Some(InputGenerationTime::from(25.0)),
         Some(toplevel_defaults),
     );
     builder.add_deme("A", vec![epochs_a], UnresolvedDemeHistory::default(), None);
@@ -62,7 +62,7 @@ demes:
 fn builder_toplevel_epoch_defaults() {
     let _ = GraphDefaults {
         epoch: UnresolvedEpoch {
-            end_time: Some(Time::try_from(100.0).unwrap()),
+            end_time: Some(InputTime::from(100.0)),
             ..Default::default()
         },
         ..Default::default()
@@ -95,7 +95,7 @@ fn builder_toplevel_deme_defaults() {
     {
         let _ = GraphDefaults {
             deme: TopLevelDemeDefaults {
-                start_time: Some(Time::try_from(100.0).unwrap()),
+                start_time: Some(InputTime::from(100.0)),
                 ..Default::default()
             },
             ..Default::default()
@@ -115,7 +115,7 @@ fn builder_toplevel_deme_defaults() {
     {
         let _ = GraphDefaults {
             deme: TopLevelDemeDefaults {
-                proportions: Some(vec![Proportion::try_from(1.0).unwrap()]),
+                proportions: Some(vec![InputProportion::from(1.0)]),
                 ..Default::default()
             },
             ..Default::default()
@@ -131,7 +131,7 @@ fn test_metadata_round_trip_through_builder() {
         bar: String,
     }
     let edata = demes::UnresolvedEpoch {
-        start_size: Some(demes::DemeSize::from(100.0)),
+        start_size: Some(demes::InputDemeSize::from(100.0)),
         ..Default::default()
     };
     let mut builder = demes::GraphBuilder::new_generations(None);

--- a/demes/tests/test_graph.rs
+++ b/demes/tests/test_graph.rs
@@ -10,16 +10,21 @@ struct ExpectedMigration {
 }
 
 impl ExpectedMigration {
-    fn new<N: ToString, M: Into<MigrationRate>, S: Into<Time>, E: Into<Time>>(
+    fn new<
+        N: ToString,
+        M: TryInto<MigrationRate, Error = demes::DemesError>,
+        S: TryInto<Time, Error = demes::DemesError>,
+        E: TryInto<Time, Error = demes::DemesError>,
+    >(
         source: N,
         dest: N,
         rate: M,
         start_time: S,
         end_time: E,
     ) -> Result<Self, demes::DemesError> {
-        let rate = rate.into();
-        let start_time = start_time.into();
-        let end_time = end_time.into();
+        let rate = rate.try_into()?;
+        let start_time = start_time.try_into()?;
+        let end_time = end_time.try_into()?;
         Ok(Self {
             source: source.to_string(),
             dest: dest.to_string(),


### PR DESCRIPTION
Introduce "input" versions of newtypes that are From<f64>,
allowing our final newtypes to be TryFrom<f64>.

This change may eventually facilitate the current newtypes
being non-constructible by client code, but we won't go
there in this PR.
