### PR TITLE
Use build.rs to build spec tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: recursive
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable

--- a/demes/Cargo.toml
+++ b/demes/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "demes"
+build = "build.rs"
 version = "0.5.0"
 edition = "2021"
 license = "MIT"
@@ -28,7 +29,6 @@ default-features = false
 features = ["std", "unicode-perl"]
 
 [dev-dependencies]
-glob = "0.3.0"
 anyhow = "~1"
 
 [[example]]

--- a/demes/build.rs
+++ b/demes/build.rs
@@ -1,0 +1,63 @@
+use std::env;
+use std::fs::read_dir;
+use std::fs::DirEntry;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    build_valid_spec_examples_tests();
+    build_invalid_spec_examples_tests();
+}
+
+fn build_valid_spec_examples_tests() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let destination = Path::new(&out_dir).join("valid_specification_tests.rs");
+    let mut test_file = File::create(&destination).unwrap();
+    let paths = read_dir("demes-spec/test-cases/valid").unwrap();
+    for p in paths {
+        let p = p.unwrap();
+        write_valid_example_test(&mut test_file, &p);
+    }
+}
+
+fn write_valid_example_test(test_file: &mut File, path: &DirEntry) {
+    let directory = path.path().canonicalize().unwrap();
+    let test_name = directory.file_name().unwrap().to_string_lossy();
+    let full_path = directory.to_string_lossy();
+    let test_name = test_name.replace(".yaml", "");
+    let test_name = format!("test_valid_case_{}", test_name);
+    write!(
+        test_file,
+        include_str!("./tests/valid_test_template"),
+        name = test_name,
+        path = full_path,
+    )
+    .unwrap();
+}
+
+fn build_invalid_spec_examples_tests() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let destination = Path::new(&out_dir).join("invalid_specification_tests.rs");
+    let mut test_file = File::create(&destination).unwrap();
+    let paths = read_dir("demes-spec/test-cases/invalid").unwrap();
+    for p in paths {
+        let p = p.unwrap();
+        write_invalid_example_test(&mut test_file, &p);
+    }
+}
+
+fn write_invalid_example_test(test_file: &mut File, path: &DirEntry) {
+    let directory = path.path().canonicalize().unwrap();
+    let test_name = directory.file_name().unwrap().to_string_lossy();
+    let full_path = directory.to_string_lossy();
+    let test_name = test_name.replace(".yaml", "");
+    let test_name = format!("test_invalid_case_{}", test_name);
+    write!(
+        test_file,
+        include_str!("./tests/invalid_test_template"),
+        name = test_name,
+        path = full_path,
+    )
+    .unwrap();
+}

--- a/demes/tests/invalid_test_template
+++ b/demes/tests/invalid_test_template
@@ -1,0 +1,7 @@
+#[test]
+fn {name}() {{
+    let yaml = "{path}";
+    let file = std::fs::File::open(yaml).unwrap();
+    let result = demes::load(file);
+    assert!(result.is_err());
+}}

--- a/demes/tests/test_cases_from_spec.rs
+++ b/demes/tests/test_cases_from_spec.rs
@@ -1,66 +1,26 @@
-use glob::glob;
+use demes::Graph;
 
-fn invalid_file_skip_list() -> std::collections::HashSet<String> {
-    let mut rv = std::collections::HashSet::default();
-
-    rv.insert("demes-spec/test-cases/invalid/bad_demelevel_defaults_epoch_43.yaml".to_string());
-    rv.insert("demes-spec/test-cases/invalid/bad_toplevel_defaults_epoch_43.yaml".to_string());
-    rv.insert("demes-spec/test-cases/invalid/bad_size_function_04.yaml".to_string());
-
-    rv
+fn round_trip_equality(graph: &Graph) {
+    let s = graph.as_string().unwrap();
+    let round_trip = demes::loads(&s).unwrap();
+    assert_eq!(graph, &round_trip);
 }
 
-fn process_path(
-    path: &str,
-    skip_list: Option<std::collections::HashSet<String>>,
-) -> (Vec<String>, Vec<String>) {
-    let paths = glob(path).unwrap();
-    let mut failures = vec![];
-    let mut successes = vec![];
-    for path in paths {
-        let name = path.unwrap();
-        let should_skip = match skip_list.as_ref() {
-            None => false,
-            Some(sl) => sl.contains(&name.clone().to_str().unwrap().to_string()),
-        };
+#[cfg(not(feature = "json"))]
+fn json_roundtrip(_: Graph, _: &str) {}
 
-        if !should_skip {
-            let file = std::fs::File::open(name.clone()).unwrap();
-            match demes::load(file) {
-                Ok(graph) => {
-                    let s = graph.as_string().unwrap();
-                    let round_trip = demes::loads(&s).unwrap();
-                    assert_eq!(graph, round_trip);
-                    successes.push(name.to_str().unwrap().to_owned());
-                    #[cfg(feature = "json")]
-                    {
-                        let json = graph.as_json_string().unwrap();
-                        let graph_from_json = demes::loads_json(&json).unwrap();
-                        assert_eq!(graph, graph_from_json, "{name:?}");
-                        assert_eq!(round_trip, graph_from_json, "{name:?}");
+#[cfg(feature = "json")]
+fn json_roundtrip(graph: Graph, filename: &str) {
+    let json = graph.as_json_string().unwrap();
+    let graph_from_json = demes::loads_json(&json).unwrap();
+    assert_eq!(graph, graph_from_json, "{filename:?}");
 
-                        // Read from a type implementing Read
-                        let raw_bytes = json.as_bytes();
-                        let graph_from_raw_bytes = demes::load_json(raw_bytes).unwrap();
-                        assert_eq!(graph, graph_from_raw_bytes);
-                    }
-                }
-                Err(_) => failures.push(name.to_str().unwrap().to_owned()),
-            }
-        }
-    }
-    (successes, failures)
+    // Read from a type implementing Read
+    let raw_bytes = json.as_bytes();
+    let graph_from_raw_bytes = demes::load_json(raw_bytes).unwrap();
+    assert_eq!(graph, graph_from_raw_bytes);
 }
 
-#[test]
-fn load_valid_graphs() {
-    let rv = process_path("demes-spec/test-cases/valid/*.yaml", None);
-    assert!(rv.1.is_empty(), "{:?}", rv.1);
-}
-
-#[test]
-fn load_invalid_graphs() {
-    let skip_list = Some(invalid_file_skip_list());
-    let rv = process_path("demes-spec/test-cases/invalid/*.yaml", skip_list);
-    assert!(rv.0.is_empty(), "{:?}", rv.0);
-}
+// NOTE: these test cases are automatically build in build.rs
+include!(concat!(env!("OUT_DIR"), "/valid_specification_tests.rs"));
+include!(concat!(env!("OUT_DIR"), "/invalid_specification_tests.rs"));

--- a/demes/tests/valid_test_template
+++ b/demes/tests/valid_test_template
@@ -1,0 +1,10 @@
+#[test]
+fn {name}() {{
+    let yaml = "{path}";
+    let file = std::fs::File::open(yaml).unwrap();
+    let result = demes::load(file);
+    assert!(result.is_ok());
+    let graph = result.unwrap();
+    round_trip_equality(&graph);
+    json_roundtrip(graph, "{path}");
+}}


### PR DESCRIPTION
- add build.rs
- working out the basics
- some more setup
- getting there...
- success, but not quite what we want
- now we are there
- invalid
- remove old test method
- remove a dev-dependency
