### PR TITLE
refactor: change argument order for forward_graph_model_end_time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "demes-forward-capi"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "demes-forward",
  "libc",

--- a/demes-forward-capi/Cargo.toml
+++ b/demes-forward-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demes-forward-capi"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/molpopgen/demes-rs"

--- a/demes-forward-capi/c_example/example.c
+++ b/demes-forward-capi/c_example/example.c
@@ -45,7 +45,7 @@ process_model(const char* file)
         }
     assert(!forward_graph_is_error_state(graph));
 
-    end_time = forward_graph_model_end_time(&status, graph);
+    end_time = forward_graph_model_end_time(graph, &status);
 
     num_demes = forward_graph_number_of_demes(graph);
 

--- a/demes-forward-capi/src/lib.rs
+++ b/demes-forward-capi/src/lib.rs
@@ -601,8 +601,8 @@ pub unsafe extern "C" fn forward_graph_ancestry_proportions(
 /// `status` must be a valid pointer to an `i32`.
 #[no_mangle]
 pub unsafe extern "C" fn forward_graph_model_end_time(
-    status: *mut i32,
     graph: *const OpaqueForwardGraph,
+    status: *mut i32,
 ) -> f64 {
     *status = 0;
     if (*graph).error.is_some() || (*graph).graph.is_none() {
@@ -845,7 +845,7 @@ demes:
             let pstatus: *mut i32 = &mut status;
             ptime = unsafe { forward_graph_iterate_time(graph.as_mut_ptr(), pstatus) };
             assert_eq!(
-                unsafe { forward_graph_model_end_time(pstatus, graph.as_ptr()) },
+                unsafe { forward_graph_model_end_time(graph.as_ptr(), pstatus) },
                 151.0
             );
             assert_eq!(status, 0);
@@ -970,7 +970,7 @@ demes:
         let pstatus: *mut i32 = &mut status;
 
         assert_eq!(
-            unsafe { forward_graph_model_end_time(pstatus, graph.as_mut_ptr()) },
+            unsafe { forward_graph_model_end_time(graph.as_mut_ptr(), pstatus) },
             151.0
         );
 
@@ -1097,7 +1097,7 @@ demes:
                 0,
             );
             assert_eq!(
-                unsafe { forward_graph_model_end_time(&mut status, graph.as_ptr()) },
+                unsafe { forward_graph_model_end_time(graph.as_ptr(), &mut status) },
                 11.0
             );
             // Iterator time starts at "next time - 1", so we need to advance

--- a/demes-forward-capi/tests/test_error_cases.rs
+++ b/demes-forward-capi/tests/test_error_cases.rs
@@ -53,7 +53,7 @@ fn test_errors_const_api_with_uninitialized_graph() {
 
     status = 0;
     let _ =
-        unsafe { forward_graph_model_end_time(&mut status, graph as *const OpaqueForwardGraph) };
+        unsafe { forward_graph_model_end_time(graph as *const OpaqueForwardGraph, &mut status) };
     assert!(status < 0);
 
     unsafe {


### PR DESCRIPTION
The API is now more idiomatic and consistent with other functions.

BREAKING CHANGE: argument order changed
