### PR TITLE
Add internal API for removing ancient past from a Graph

### DIFF
--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -3544,6 +3544,8 @@ impl Graph {
             }
         }
 
+        todo!("migrations and pulses");
+
         unresolved.resolve()?;
         unresolved.validate()?;
         unresolved.try_into()

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -3488,9 +3488,12 @@ impl Graph {
             time >= end_time && time < start_time
         });
 
-        unresolved.demes.iter_mut().for_each(|deme| todo!());
+        for demes in &mut unresolved.demes {
+            if let Some(start_time) = demes.history.start_time {
+                todo!()
+            }
+        }
 
-        unresolved.demes.iter_mut().for_each(|deme| todo!());
         unresolved.resolve()?;
         unresolved.validate()?;
         unresolved.try_into()

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -3484,9 +3484,10 @@ impl Graph {
 
         // Remove all demes that just don't overlap
         unresolved.demes.retain(|d| {
-            let start_time = d.history.start_time.unwrap();
+            //let start_time = d.history.start_time.unwrap();
             let end_time = d.epochs.last().unwrap().end_time.unwrap();
-            time >= end_time && time < start_time
+            end_time < time
+            //time >= end_time && time < start_time
         });
 
         // truncate epochs

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -3499,9 +3499,33 @@ impl Graph {
             } else {
                 deme.epochs.clear();
             }
-            println!("{:?}",deme.epochs);
-            if let Some(start_time) = deme.history.start_time {
-                todo!()
+        }
+
+        unresolved.demes.retain(|d| !d.epochs.is_empty());
+
+        let names = unresolved
+            .demes
+            .iter()
+            .map(|d| d.name.clone())
+            .collect::<Vec<_>>();
+
+        for deme in &mut unresolved.demes {
+            if let Some(ancestors) = deme.history.ancestors.as_mut() {
+                // FIXME: this is broken for cases of multiple ancestors
+                // but only SOME are clipped
+                ancestors.retain(|a| names.contains(a));
+                if ancestors.is_empty() {
+                    deme.history.ancestors = None;
+                    deme.history.proportions = None;
+                }
+            }
+            if deme.history.ancestors.is_none() {
+                if let Some(start_time) = deme.history.start_time {
+                    if f64::from(start_time).is_finite() {
+                        // then this deme had ancestors and they've all been lost
+                        deme.history.start_time = Some(f64::INFINITY.into())
+                    }
+                }
             }
         }
 

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -4621,4 +4621,17 @@ demes:
             assert_eq!(deme.end_time(), 0.)
         }
     }
+
+    #[test]
+    fn test_yaml1_b() {
+        let graph = crate::loads(YAML1).unwrap();
+        let trimmed = graph.remove_ancient_past(100.0).unwrap();
+        assert_eq!(trimmed.num_demes(), 4);
+    }
+
+    #[test]
+    fn test_yaml1_c() {
+        let graph = crate::loads(YAML1).unwrap();
+        assert!(graph.remove_ancient_past(0.0).is_err());
+    }
 }

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -3481,7 +3481,19 @@ impl Graph {
         let time = time.try_into()?;
         let time = InputTime::from(f64::from(time));
         let mut unresolved = UnresolvedGraph::from(self);
-        todo!()
+        // Remove all demes that just don't overlap
+        unresolved.demes.retain(|d| {
+            let start_time = d.history.start_time.unwrap();
+            let end_time = d.epochs.last().unwrap().end_time.unwrap();
+            time >= end_time && time < start_time
+        });
+
+        unresolved.demes.iter_mut().for_each(|deme| todo!());
+
+        unresolved.demes.iter_mut().for_each(|deme| todo!());
+        unresolved.resolve()?;
+        unresolved.validate()?;
+        unresolved.try_into()
     }
 }
 

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -4663,8 +4663,12 @@ demes:
     #[test]
     fn test_yaml2() {
         let graph = crate::loads(YAML2).unwrap();
-        // This is an error b/c we leave a growing deme
-        // as the only deme, which is invalid.
-        assert!(graph.remove_ancient_past(100.).is_err());
+        // TODO: decide what to do here
+        // this slice clips off the ancestor.
+        // Without additional steps, we Err b/c our oldest epoch
+        // is growing.
+        // What Aaron does is to add an earlier epoch that is
+        // constant size with the "size_at" for the slice time.
+        graph.remove_ancient_past(100.).unwrap();
     }
 }

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -3481,6 +3481,7 @@ impl Graph {
         let time = time.try_into()?;
         let time = InputTime::from(f64::from(time));
         let mut unresolved = UnresolvedGraph::from(self);
+
         // Remove all demes that just don't overlap
         unresolved.demes.retain(|d| {
             let start_time = d.history.start_time.unwrap();
@@ -3488,8 +3489,18 @@ impl Graph {
             time >= end_time && time < start_time
         });
 
-        for demes in &mut unresolved.demes {
-            if let Some(start_time) = demes.history.start_time {
+        // truncate epochs
+        for deme in &mut unresolved.demes {
+            if let Some(index) = deme.epochs.iter().position(|e| {
+                let end_time = e.end_time.unwrap();
+                time >= end_time
+            }) {
+                deme.epochs.truncate(index + 1);
+            } else {
+                deme.epochs.clear();
+            }
+            println!("{:?}",deme.epochs);
+            if let Some(start_time) = deme.history.start_time {
                 todo!()
             }
         }


### PR DESCRIPTION
Complements #391, removing ancient history from a demes::Graph
