### PR TITLE
test: improve testing of JSON input

### DIFF
--- a/demes/src/lib.rs
+++ b/demes/src/lib.rs
@@ -51,6 +51,9 @@ mod selfing_rate;
 mod specification;
 mod time;
 
+#[cfg(feature = "json")]
+mod process_json;
+
 #[cfg(feature = "ffi")]
 pub mod ffi;
 

--- a/demes/src/process_json.rs
+++ b/demes/src/process_json.rs
@@ -1,0 +1,60 @@
+use crate::DemesError;
+
+fn fix_null_start_times_demes(value: &mut serde_json::Value) -> Result<(), DemesError> {
+    if let serde_json::Value::Array(demes) = value {
+        // JSON has no encoding for infinity or NaN.
+        // If an input file contains .inf, the JSON reader
+        // will convert it to null, which is what the JSON
+        // spec requires (AFAIK).
+        // However, that encoding violates the demes spec,
+        // so we replace those values with a string that we
+        // can interpret.
+        for deme in demes {
+            if let Some(value) = deme.get_mut("start_time") {
+                if let &mut serde_json::Value::Null = value {
+                    let inf: &str = "Infinity";
+                    *value = serde_json::Value::from(inf);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn fix_null_start_times(
+    input: std::collections::HashMap<String, serde_json::Value>,
+) -> Result<std::collections::HashMap<String, serde_json::Value>, DemesError> {
+    let mut input = input;
+    if let Some(demes) = input.get_mut("demes") {
+        fix_null_start_times_demes(demes)?;
+    }
+    Ok(input)
+}
+
+pub fn fix_json_input(
+    input: std::collections::HashMap<String, serde_json::Value>,
+) -> Result<std::collections::HashMap<String, serde_json::Value>, DemesError> {
+    let input = fix_null_start_times(input)?;
+    Ok(input)
+}
+
+#[test]
+fn test_json_conversion() {
+    use std::io::Read;
+
+    let mut f =
+        std::fs::File::open("demes-spec/test-cases/valid/defaults_deme_ancestors.yaml").unwrap();
+    let mut buf = String::new();
+    let _ = f.read_to_string(&mut buf).unwrap();
+    let json: serde_json::Value = serde_yaml::from_str::<serde_json::Value>(&buf).unwrap();
+    let json = json.to_string();
+    let json: std::collections::HashMap<String, serde_json::Value> =
+        serde_json::from_str(&json).unwrap();
+    let json = fix_json_input(json).unwrap();
+    let json = serde_json::to_string(&json).unwrap();
+    let g = crate::loads_json(&json).unwrap();
+    let f =
+        std::fs::File::open("demes-spec/test-cases/valid/defaults_deme_ancestors.yaml").unwrap();
+    let gy = crate::load(f).unwrap();
+    assert_eq!(g, gy);
+}

--- a/demes/src/specification.rs
+++ b/demes/src/specification.rs
@@ -3020,7 +3020,11 @@ impl Graph {
     #[cfg(feature = "json")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "json")))]
     pub(crate) fn new_resolved_from_json_str(json: &'_ str) -> Result<Self, DemesError> {
-        let mut g: UnresolvedGraph = serde_json::from_str(json)?;
+        let json: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_str(json)?;
+        let json = crate::process_json::fix_json_input(json)?;
+        let json = serde_json::to_string(&json)?;
+        let mut g: UnresolvedGraph = serde_json::from_str(&json)?;
         g.resolve()?;
         g.validate()?;
         g.input_string = Some(InputFormatInternal::Json(json.to_owned()));

--- a/demes/tests/test_cases_from_spec.rs
+++ b/demes/tests/test_cases_from_spec.rs
@@ -23,12 +23,15 @@ fn round_trip_equality(graph: &Graph) {
     assert_eq!(graph, &round_trip);
 }
 
-#[cfg(not(feature = "json"))]
-fn json_roundtrip(_: Graph, _: &str) {}
-
 #[cfg(feature = "json")]
 fn json_roundtrip(graph: Graph, filename: &str) {
-    let json = graph.as_json_string().unwrap();
+    use std::io::Read;
+
+    let mut f = std::fs::File::open(filename).unwrap();
+    let mut buf = String::new();
+    let _ = f.read_to_string(&mut buf).unwrap();
+    let json = serde_yaml::from_str::<serde_json::Value>(&buf).unwrap();
+    let json = json.to_string();
     let graph_from_json = demes::loads_json(&json).unwrap();
     assert_eq!(graph, graph_from_json, "{filename:?}");
 

--- a/demes/tests/valid_test_template
+++ b/demes/tests/valid_test_template
@@ -7,5 +7,6 @@ fn {name}() {{
     let graph = result.unwrap();
     validate_names_in_graph(&graph);
     round_trip_equality(&graph);
+    #[cfg(feature = "json")]
     json_roundtrip(graph, "{path}");
 }}


### PR DESCRIPTION
Refactor the tests of valid spec cases to auto-convert from
the input YAML to JSON using serde.

This change means that we are no longer relying on
fully-resolved graphs for testing JSON input,
which is an improvement.
The previous implementation read in the YAML,
output to JSON, and then recreated a graph from the JSON.
Such an approach is somewhat circular and the JSON string
represented a fully-resolved graph.
